### PR TITLE
Adding constant= function

### DIFF
--- a/include/janetls.h
+++ b/include/janetls.h
@@ -48,6 +48,7 @@ const char * result_error_message(int result, uint8_t * unhandled);
 int flatten_array(Janet * output, JanetArray * array);
 int janet_byte_cstrcmp_insensitive(JanetByteView str, const char * other);
 int janet_byte_cstrcmp_sensitive(JanetByteView str, const char * other);
+int janetls_constant_compare(Janet x, Janet y);
 
 typedef enum string_type {
   STRING_IS_DIGITS,
@@ -65,6 +66,7 @@ string_type classify_string(const uint8_t * data, int32_t length);
 
 void submod_md(JanetTable * env);
 void submod_util(JanetTable * env);
+void submod_encoding(JanetTable * env);
 void submod_bignum(JanetTable * env);
 void submod_random(JanetTable * env);
 void submod_byteslice(JanetTable * env);

--- a/src/janetls-encoding.c
+++ b/src/janetls-encoding.c
@@ -200,7 +200,7 @@ static const JanetReg cfuns[] =
   {NULL, NULL, NULL}
 };
 
-void submod_util(JanetTable *env)
+void submod_encoding(JanetTable *env)
 {
   janet_cfuns(env, "janetls", cfuns);
 }

--- a/src/janetls.c
+++ b/src/janetls.c
@@ -33,6 +33,7 @@ JANET_MODULE_ENTRY(JanetTable *env)
 {
   submod_md(env);
   submod_util(env);
+  submod_encoding(env);
   submod_bignum(env);
   submod_random(env);
   submod_byteslice(env);

--- a/test/util.janet
+++ b/test/util.janet
@@ -1,0 +1,16 @@
+(import testament :prefix "" :exit true)
+# Testament framework documentation
+# https://github.com/pyrmont/testament/blob/master/api.md
+(import ../build/janetls :prefix "" :exit true)
+
+(deftest "Constant= checks"
+  (is (constant= "abcd" "abcd"))
+  (is (constant= "abcd" @"abcd"))
+  (is (constant= @"abcd" :abcd))
+  (is (constant= "abcd" :abcd))
+  (is (not (constant= "abcd" "abc")))
+  (is (not (constant= "abcd" 5)))
+  (is (not (constant= "abcd" {:hi "hello"})))
+  )
+
+(run-tests!)


### PR DESCRIPTION
As prompted by @andrewchambers this adds a constant comparison method for janet strings / buffers / keywords.

Andrew was previously converting strings to keywords and comparing those, which was quite hacky.

The core comparison method `|= a ^ b` is common for constant time comparison, but requires both buffers to be of equal length. All casting and length comparisons happen prior to this stage.