### PR TITLE
Mbedtlsv2.26.0, Janet 1.15 fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ scratchpad.txt
 .vscode
 crash*.janet
 scratchfolder
+.DS_Store

--- a/src/janetls-aes.c
+++ b/src/janetls-aes.c
@@ -163,13 +163,14 @@ static int aes_gcmark(void * data, size_t len)
   return 0;
 }
 
-static int aes_get_fn(void *data, Janet key, Janet * out)
+static int aes_get_fn(void * data, Janet key, Janet * out)
 {
   (void)data;
 
   if (!janet_checktype(key, JANET_KEYWORD))
   {
-    janet_panicf("expected keyword, got %p", key);
+    // Unexpected type, not found.
+    return 0;
   }
 
   return janet_getmethod(janet_unwrap_keyword(key), aes_methods, out);

--- a/src/janetls-bignum.c
+++ b/src/janetls-bignum.c
@@ -103,13 +103,14 @@ static JanetMethod bignum_methods[] = {
 // janet_checkint64range and janet_checkintrange will check that the conversion
 // poses no loss, in that there is no fractional portion.
 
-static int bignum_get_fn(void *data, Janet key, Janet * out)
+static int bignum_get_fn(void * data, Janet key, Janet * out)
 {
   (void)data;
 
   if (!janet_checktype(key, JANET_KEYWORD))
   {
-    janet_panicf("expected keyword, got %p", key);
+    // Unexpected type, not found.
+    return 0;
   }
 
   return janet_getmethod(janet_unwrap_keyword(key), bignum_methods, out);

--- a/src/janetls-byteslice.c
+++ b/src/janetls-byteslice.c
@@ -41,13 +41,14 @@ static JanetMethod byteslice_methods[] = {
   {NULL, NULL}
 };
 
-static int byteslice_get_fn(void *data, Janet key, Janet * out)
+static int byteslice_get_fn(void * data, Janet key, Janet * out)
 {
   (void)data;
 
   if (!janet_checktype(key, JANET_KEYWORD))
   {
-    janet_panicf("expected keyword, got %p", key);
+    // Unexpected type, not found.
+    return 0;
   }
 
   return janet_getmethod(janet_unwrap_keyword(key), byteslice_methods, out);

--- a/src/janetls-chacha.c
+++ b/src/janetls-chacha.c
@@ -161,13 +161,14 @@ static int chacha_gcmark(void * data, size_t len)
   return 0;
 }
 
-static int chacha_get_fn(void *data, Janet key, Janet * out)
+static int chacha_get_fn(void * data, Janet key, Janet * out)
 {
   (void)data;
 
   if (!janet_checktype(key, JANET_KEYWORD))
   {
-    janet_panicf("expected keyword, got %p", key);
+    // Unexpected type, not found.
+    return 0;
   }
 
   return janet_getmethod(janet_unwrap_keyword(key), chacha_methods, out);

--- a/src/janetls-chachapoly.c
+++ b/src/janetls-chachapoly.c
@@ -197,14 +197,15 @@ static int chachapoly_gcmark(void * data, size_t len)
   return 0;
 }
 
-static int chachapoly_get_fn(void *data, Janet key, Janet * out)
+static int chachapoly_get_fn(void * data, Janet key, Janet * out)
 {
   (void)data;
 
   if (!janet_checktype(key, JANET_KEYWORD))
   {
-    janet_panicf("expected keyword, got %p", key);
-  }
+    // Unexpected type, not found.
+    return 0;
+  } 
 
   return janet_getmethod(janet_unwrap_keyword(key), chachapoly_methods, out);
 }

--- a/src/janetls-ecdsa.c
+++ b/src/janetls-ecdsa.c
@@ -190,7 +190,8 @@ static int ecdsa_get_fn(void * data, Janet key, Janet * out)
 
   if (!janet_checktype(key, JANET_KEYWORD))
   {
-    janet_panicf("expected keyword, got %p", key);
+    // Unexpected type, not found.
+    return 0;
   }
 
   return janet_getmethod(janet_unwrap_keyword(key), ecdsa_methods, out);

--- a/src/janetls-ecp.c
+++ b/src/janetls-ecp.c
@@ -252,13 +252,14 @@ JanetAbstractType * janetls_ecp_keypair_object_type()
   return &ecp_keypair_object_type;
 }
 
-static int ecp_group_get_fn(void *data, Janet key, Janet * out)
+static int ecp_group_get_fn(void * data, Janet key, Janet * out)
 {
   (void)data;
 
   if (!janet_checktype(key, JANET_KEYWORD))
   {
-    janet_panicf("expected keyword, got %p", key);
+    // Unexpected type, not found.
+    return 0;
   }
 
   return janet_getmethod(janet_unwrap_keyword(key), ecp_group_methods, out);
@@ -292,13 +293,14 @@ static int ecp_group_gcmark(void *data, size_t len)
   return 0;
 }
 
-static int ecp_point_get_fn(void *data, Janet key, Janet * out)
+static int ecp_point_get_fn(void * data, Janet key, Janet * out)
 {
   (void)data;
 
   if (!janet_checktype(key, JANET_KEYWORD))
   {
-    janet_panicf("expected keyword, got %p", key);
+    // Unexpected type, not found.
+    return 0;
   }
 
   return janet_getmethod(janet_unwrap_keyword(key), ecp_point_methods, out);
@@ -334,13 +336,14 @@ static int ecp_point_gcmark(void *data, size_t len)
   return 0;
 }
 
-static int ecp_keypair_get_fn(void *data, Janet key, Janet * out)
+static int ecp_keypair_get_fn(void * data, Janet key, Janet * out)
 {
   (void)data;
 
   if (!janet_checktype(key, JANET_KEYWORD))
   {
-    janet_panicf("expected keyword, got %p", key);
+    // Unexpected type, not found.
+    return 0;
   }
 
   return janet_getmethod(janet_unwrap_keyword(key), ecp_keypair_methods, out);

--- a/src/janetls-gcm.c
+++ b/src/janetls-gcm.c
@@ -188,13 +188,14 @@ static int gcm_gcmark(void * data, size_t len)
   return 0;
 }
 
-static int gcm_get_fn(void *data, Janet key, Janet * out)
+static int gcm_get_fn(void * data, Janet key, Janet * out)
 {
   (void)data;
 
   if (!janet_checktype(key, JANET_KEYWORD))
   {
-    janet_panicf("expected keyword, got %p", key);
+    // Unexpected type, not found.
+    return 0;
   }
 
   return janet_getmethod(janet_unwrap_keyword(key), gcm_methods, out);

--- a/src/janetls-md.c
+++ b/src/janetls-md.c
@@ -167,7 +167,8 @@ static int md_get_fn(void * data, Janet key, Janet * out)
 
   if (!janet_checktype(key, JANET_KEYWORD))
   {
-    janet_panicf("expected keyword, got %p", key);
+    // Unexpected type, not found.
+    return 0;
   }
 
   JanetKeyword method = janet_unwrap_keyword(key);

--- a/src/janetls-random.c
+++ b/src/janetls-random.c
@@ -44,13 +44,14 @@ static JanetMethod random_methods[] = {
 // janet_checkint64range and janet_checkintrange will check that the conversion
 // poses no loss, in that there is no fractional portion.
 
-static int random_get_fn(void *data, Janet key, Janet * out)
+static int random_get_fn(void * data, Janet key, Janet * out)
 {
   (void)data;
 
   if (!janet_checktype(key, JANET_KEYWORD))
   {
-    janet_panicf("expected keyword, got %p", key);
+    // Unexpected type, not found.
+    return 0;
   }
 
   return janet_getmethod(janet_unwrap_keyword(key), random_methods, out);

--- a/src/janetls-rsa.c
+++ b/src/janetls-rsa.c
@@ -88,7 +88,8 @@ static int rsa_get_fn(void * data, Janet key, Janet * out)
 
   if (!janet_checktype(key, JANET_KEYWORD))
   {
-    janet_panicf("expected keyword, got %p", key);
+    // Unexpected type, not found.
+    return 0;
   }
 
   return janet_getmethod(janet_unwrap_keyword(key), rsa_methods, out);


### PR DESCRIPTION
Bump Mbed TLS version, fix panic in abstract type get functions, as this is no longer caught during the `match` macro. 