### PR TITLE
Fix the pk/wrap function for use with pk/generate, add version and curve group

### DIFF
--- a/janetls/pk.janet
+++ b/janetls/pk.janet
@@ -707,7 +707,9 @@
 , consider using the optional parameter pk-type on the function pk/wrap" key-type)
     )))
   (def information-class (:information-class key))
-  (def pk @{:key key :type kind :information-class information-class})
+  (def curve-group (if (= kind :ecdsa) (:curve-group key)))
+  (def version (if (= kind :rsa) (:version key)))
+  (def pk @{:key key :type kind :information-class information-class :curve-group curve-group :version version})
   (table/setproto pk PK-Prototype)
   )
 

--- a/test/pk.janet
+++ b/test/pk.janet
@@ -441,9 +441,18 @@ wEYF/pxNtkoMO4CzC+XtZWhRVMsgtfPaOgcCb5EamDXYV68Ius9v7VZ9jQ==\n
   (ck (pk/generate :ecdsa :secp256r1))
   (ck (pk/generate :ecdsa :secp384r1))
   (ck (pk/generate :ecdsa :secp521r1))
+
   (assert-thrown (pk/generate :rsa "hello"))
   (assert-thrown (pk/generate :rsa 1025))
   (assert-thrown (pk/generate :ecdsa :secp521k1))
+  (def rsakey (pk/generate :rsa))
+  (def ecdsakey (pk/generate :ecdsa))
+  (is (= :private (rsakey :information-class)))
+  (is (= :private (ecdsakey :information-class)))
+  (is (= :rsa (rsakey :type)))
+  (is (= :ecdsa (ecdsakey :type)))
+  (is (= :pkcs1-v1.5 (rsakey :version)))
+  (is (= :secp256r1 (ecdsakey :curve-group)))
   )
 
 


### PR DESCRIPTION
These fields were missing and are normally available when `pk/import` is used.