### PR TITLE
Add error code text for bignum encoding error.

### DIFF
--- a/src/janetls.c
+++ b/src/janetls.c
@@ -76,6 +76,8 @@ const char * result_error_message(int result, uint8_t * unhandled)
       return "MPI: Cannot parse, an invalid character was found";
     case MBEDTLS_ERR_MPI_DIVISION_BY_ZERO:
       return "MPI: Division by zero";
+    case MBEDTLS_ERR_MPI_BUFFER_TOO_SMALL:
+      return "MPI: Allocated buffer is too small, this is an internal error";
     case MBEDTLS_ERR_MD_ALLOC_FAILED:
     case MBEDTLS_ERR_MPI_ALLOC_FAILED:
     case JANETLS_ERR_ALLOCATION_FAILED:


### PR DESCRIPTION
When exporting ECDSA keys, if the key is invalid (Y coordinate has too many bits) it would give a mysterious error code.
This makes it slightly less mysterious.

More validation is necessary on import:
I found that if the Y coordinate of a P-256 key has 263 bits (obviously more than 256)
then it errors out while exporting that key.